### PR TITLE
Fix support for nightwatch tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,41 +3,75 @@
 
 [![Build Status](https://travis-ci.org/kaizendorks/vue-cli-plugin-vuedock.svg?branch=master)](https://travis-ci.org/kaizendorks/vue-cli-plugin-vuedock)
 
-## Instructions
-
-#### Description
-Generates Docker/Docker-compose files for:
+This plugin generates the necessary docker and docker-compose files for:
 - running the local development server.
 - running eslint and unit tests
+- running e2e tests, automatically detecting cypress and nightwatch tests
 - creating a production ready image, built on top of the official nginx Docker image.
 
-#### Installation in a Vue project
-Simply run the following command from your project's root folder: `vue add vuedock`
+Contents
+- [Installation](#installation)
+    - [Options](#options)
+        - [Add dgoss tests](#add-dgoss-tests)
+- [Usage](#usage)
+    - [Usage in development](#usage-in-development)
+    - [Usage in CI servers](#usage-in-ci-servers)
+    - [Usage in production](#usage-in-prod)
+- [Contributing](#contributingsage)
+    - [Development in your local environment](#development-in-your-local-environment)
+    - [Development in a dockerized environment](#development-in-a-dockerized-environment)
+    - [CI](#ci)
 
-For more information, see: https://cli.vuejs.org/guide/plugins-and-presets.html#installing-plugins-in-an-existing-project
+## Installation
+Run the following command from your project's root folder: `vue add vuedock`
 
-#### Usage: Dev (Example using Yarn)
+- For more information on how to add plugins to your project, see: https://cli.vuejs.org/guide/plugins-and-presets.html#installing-plugins-in-an-existing-project
+
+This will generate the following files in your project root:
+
+- `Dockerfile`, multi-stage docker image used for local development and CI/Prod. Will use npm/yarn for the server and build commands depending on whether a `yarn.lock` file was detected when the plugin was installed
+- `docker-compose.yml`, compose file to be used during local development for running and testing your app. Will include extra containers for running E2E and Cypress E2E tests if these were detected when the plugin was installed.
+- `.dockerignore`, default ignore file
+
+### Options
+
+#### Add dgoss tests
+
+You can optionally generate a `goss.yaml` file ready to test your production container using [goss](https://github.com/aelsabbahy/goss) and [dgoss](https://github.com/aelsabbahy/goss/tree/master/extras/dgoss) (a docker wrapper for goss)
+
+When adding the plugin, you will be automatically prompted whether you want to add dgoss tests or not.
+
+## Usage
+
+### Usage in development
 
 1. Run Vue Application:
 
+        # start the dev server, then navigate to http://localhost:8080 to see your app
         docker-compose up app
 
 1. Run ESLint:
 
+        # Using yarn
         docker-compose run --rm app yarn lint
+        # Using npm
+        docker-compose run --rm app npm run lint
 
 1. Run Unit Tests:
 
+        # Using yarn
         docker-compose run --rm app yarn test:unit
+        # Using npm
+        docker-compose run --rm app npm run test:unit
 
-1. Run E2E Tests **(Currently only supports Cypress):**
+1. Run E2E Tests (generated files support cypress and nightwatch out of the box)
 
-        # Run tests, this will also run the app container.
+        # Run tests (this will also run the app container if it wasnt already running)
         docker-compose run --rm test_e2e
         # To clean up
         docker-compose down
 
-#### Usage: CI Server (Example using NPM)
+### Usage in CI Servers
 
 1. Build CI ready Docker image:
 
@@ -45,20 +79,26 @@ For more information, see: https://cli.vuejs.org/guide/plugins-and-presets.html#
 
 1. Run linting
 
+        # Usign yarn
+        docker run --rm vueapp yarn lint
+        # Using npm
         docker run --rm vueapp npm run lint
 
 1. Run unit test:
 
+        # Usign yarn
+        docker run --rm vueapp yarn test:unit
+        # Using npm
         docker run --rm vueapp npm run test:unit
 
-1. Run E2E Tests **(Currently only supports Cypress):**
+1. Run E2E Tests (generated files support cypress and nightwatch out of the box)
 
-        # Run tests, this will also run the app container.
+        # Run tests (this will also run the app container if it wasnt already running)
         docker-compose run --rm test_e2e
         # To clean up
         docker-compose down
 
-1. **Note:** You can update the E2E tests to point at any running site by changing the CYPRESS_baseUrl environment variable passed into the container. That ability means that this would also be a great basis for implementing some very complex and cool delivery and rollback pipelines.
+    - **Note:** You can update the E2E tests to point at any running site by changing either the `CYPRESS_baseUrl` or `LAUNCH_URL` environment variable passed into the container (dependending on whether you use cypress or nightwatch for E2E tests). That ability means that this would also be a great basis for implementing some very complex and cool delivery and rollback pipelines.
 
 1. Build you production image:
 
@@ -71,25 +111,43 @@ For more information, see: https://cli.vuejs.org/guide/plugins-and-presets.html#
           -v /var/run/docker.sock:/var/run/docker.sock \
         iorubs/dgoss run vueapp
 
-#### Usage: Prod
+#### Usage in production
 
-1. Run production app:
+1. Run production app built in CI server
 
         docker run --rm -p 8080:80 vueapp
         # Open port 8080 to see some output.
 
 ## Contributing
 
-#### Development
+Start by cloning this repo. Then you can develop this plugin fully in a dockerized environment or in your local environment.
+
+### Development in your local environment
+
+1. Copy the full path to your copy of this repo
+
+        pwd
+        # copy path like /Users/chuck/git/kaizendorks/vue-cli-plugin-vuedock
+
+1. Create a test `app` project in another folder using the Vue CLI
+
+        vue create app
+
+1. Change to the new `app` project directory and locally install this plugin. You will need the path copied in step 1
+
+        cd app
+        npm install --save-dev file:/Users/chuck/git/kaizendorks/vue-cli-plugin-vuedock
+        vue invoke vue-cli-plugin-vuedock
+
+1. Once invoked, undo the changes to the package.json and package-lock.json (or yarn.lock). Otherwise install would fail in docker as it wont have access to the directory where the vue-cli-plugin-vuedock plugin is located.
+
+### Development in a dockerized environment
 
 Dockerized vue-cli
 
 ``` bash
 # Build image
 docker build -t vuedock --target vuecli .
-
-# Print help
-docker run --rm vuedock
 
 # Run a shell inside the dev container
 docker run --rm -it \
@@ -112,7 +170,7 @@ yarn add --dev file:/vuedock
 vue invoke vue-cli-plugin-vuedock
 ```
 
-#### CI
+### CI
 
 Goss is tool for validating server’s configuration (avoid conf. drift). Dgoss is a wrapper written on top of goss for validating docker images.
 https://github.com/aelsabbahy/goss/tree/master/extras/dgoss
@@ -150,8 +208,3 @@ docker run --rm -it \
   -v /var/run/docker.sock:/var/run/docker.sock \
 iorubs/dgoss edit app
 ```
-
-## Todo:
-1. Add E2E Nightwatch test support
-1. Add express support
-1. Move Contributing sections somewhere else or not?

--- a/generator/index.js
+++ b/generator/index.js
@@ -2,16 +2,15 @@
 const fs = require('fs');
 
 module.exports = (api, options) => {
-  // Disabling this for now, until we fix e2e tests
-  options.hasNightwatch = false; // api.hasPlugin('e2e-nightwatch');
-
+  // Detect which E2E (if any) are enabled
+  options.hasNightwatch = api.hasPlugin('e2e-nightwatch');
   options.hasCypress = api.hasPlugin('e2e-cypress');
 
   // At present if yarn is not used then it must be NPM.
   options.usesYarn = fs.existsSync('./yarn.lock');
 
   api.render('./template/default', options);
+  if (options.hasNightwatch || options.hasCypress) api.render('./template/e2e-common', options);
   if (options.hasNightwatch) api.render('./template/e2e-nightwatch', options);
-  if (options.hasCypress) api.render('./template/e2e-cypress', options);
   if (options.addDgossTests) api.render('./template/dgoss', options);
 };

--- a/generator/template/default/docker-compose.yml
+++ b/generator/template/default/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 <% } _%>
 <% if (hasNightwatch) { _%>
 
-  test:
+  test_e2e:
     build:
       context: .
       target: dev
@@ -48,9 +48,9 @@ services:
       - SELENIUM_PORT=4444
     # Todo: Maybe improve this by adding a script to wait for app and selinium
 <% if (usesYarn) { _%>
-    command: "sh -c 'sleep 5 && yarn test:e2e'"
+    command: "sh -c 'sleep 5 && yarn test:e2e -- --url http://app:8080'"
 <% } else { _%>
-    command: "sh -c 'sleep 5 && npm run test:e2e'"
+    command: "sh -c 'sleep 5 && npm run test:e2e -- --url http://app:8080'"
 <% } _%>
     volumes:
       - ./:/home/node/app
@@ -62,4 +62,8 @@ services:
 
   selenium-chrome: #Docs: https://github.com/SeleniumHQ/docker-selenium/tree/master/StandaloneChrome
     image: selenium/standalone-chrome
+    expose:
+      - 4444
+    # ports:
+    # - '5900:5900' # expose debug port if needed
 <% } _%>

--- a/generator/template/e2e-common/vue.config.js
+++ b/generator/template/e2e-common/vue.config.js
@@ -1,0 +1,10 @@
+// vue.config.js
+module.exports = {
+  configureWebpack: {
+    devServer: {
+      // E2E tests inside docker will run in a separated container than the test container
+      // They will be available at http://app:8080, so we need to disable the enforcing of localhost
+      disableHostCheck: true,
+    },
+  },
+};

--- a/generator/template/e2e-cypress/vue.config.js
+++ b/generator/template/e2e-cypress/vue.config.js
@@ -1,8 +1,0 @@
-// vue.config.js
-module.exports = {
-  configureWebpack: {
-    devServer: {
-      disableHostCheck: true,
-    },
-  },
-};

--- a/generator/template/e2e-nightwatch/nightwatch.config.js
+++ b/generator/template/e2e-nightwatch/nightwatch.config.js
@@ -1,12 +1,18 @@
 // Update default vue-cli-plugin-e2e-nightwatch options: https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-e2e-nightwatch
 // With these updated settings, nightwatch wont attempt to start a selenium server
-// and instead will use the selenium-chrome docker image
+// and instead will use the selenium-chrome docker image.
+
+// For additional nightwatch settings see: http://nightwatchjs.org/gettingstarted#settings-file
 
 module.exports = {
+  output_folder: 'tests/e2e/reports',
+
   selenium: {
+    log_path: 'tests/e2e/reports/',
     // eslint-disable-next-line no-unneeded-ternary
     start_process: process.env.SELENIUM_HOST ? false : true,
     start_session: true,
+    debug: false,
     host: process.env.SELENIUM_HOST || '127.0.0.1',
     port: process.env.SELENIUM_PORT || 4444,
   },
@@ -14,9 +20,15 @@ module.exports = {
   test_settings: {
     default: {
       launch_url: process.env.LAUNCH_URL || 'http://localhost:8080',
+      selenium_host: process.env.SELENIUM_HOST || '127.0.0.1',
       selenium_port: process.env.SELENIUM_PORT || 4444,
-      selenium_host: process.env.SELENIUM_HOST || 'localhost',
       silent: true,
+      screenshots: {
+        enabled: true,
+        on_failure: true,
+        on_error: true,
+        path: 'tests/e2e/reports/screenshots',
+      },
     },
 
     chrome: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-vuedock",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Vue CLI 3 plugin for adding dev/prod docker and compose files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixed the support for E2E nightwatch (similar to the issue with cypress that made us add the vue dev server options), made sure the same docker commands are valid for cypress/nightwatch and updated the readme.

<img width="493" alt="Screen Shot 2019-03-17 at 3 13 16 PM" src="https://user-images.githubusercontent.com/3903889/54493507-bfcc3100-48c8-11e9-9303-4098fd41d9fb.png">
